### PR TITLE
Voting system evaluator serialization

### DIFF
--- a/tests/real/data/cz_psp_2017.csv
+++ b/tests/real/data/cz_psp_2017.csv
@@ -1,4 +1,4 @@
-party;Hlavní město Praha;Středočeský kraj;Jihočeský kraj;Plzeňský kraj;Karlovarský kraj;Ústecký kraj;Liberecký kraj;Královéhradecký kraj;Pardubický kraj;Kraj Vysočina;Jihomoravský kraj;Olomoucký kraj;Zlínský kraj ;Moravskoslezský kraj
+party;Hlavní město Praha;Středočeský kraj;Jihočeský kraj;Plzeňský kraj;Karlovarský kraj;Ústecký kraj;Liberecký kraj;Královéhradecký kraj;Pardubický kraj;Kraj Vysočina;Jihomoravský kraj;Olomoucký kraj;Zlínský kraj;Moravskoslezský kraj
 ODS;99182;85415;38232;32833;10796;32197;21468;32242;28313;25989;69319;27266;28752;40944
 ŘN - VU;642;1353;557;558;896;631;327;531;509;324;768;426;615;598
 CESTA;407;412;255;184;0;234;196;297;355;137;477;282;195;327

--- a/tests/real/test_real_listbased.py
+++ b/tests/real/test_real_listbased.py
@@ -52,11 +52,10 @@ def nmnmet_cc_2018_data():
     return votes, party_lists, results_obj
 
 
-@pytest.fixture(scope='module')
-def nmnmet_cc_2018_evaluator():
+def get_evaluators():
     mapper = votelib.candidate.IndividualToPartyMapper(independents='error')
     vote_grouper = votelib.convert.GroupVotesByParty(mapper)
-    return votelib.evaluate.core.FixedSeatCount(
+    return [votelib.evaluate.core.FixedSeatCount(
         votelib.evaluate.core.PreConverted(
             vote_grouper,
             votelib.evaluate.core.PartyListEvaluator(
@@ -76,7 +75,12 @@ def nmnmet_cc_2018_evaluator():
             )
         ),
         21
-    )
+    )]
+
+
+@pytest.fixture(scope='module')
+def nmnmet_cc_2018_evaluator():
+    return get_evaluators()[0]
 
 
 def test_nmnmet_cc_2018(nmnmet_cc_2018_data, nmnmet_cc_2018_evaluator):

--- a/tests/real/test_real_mmp.py
+++ b/tests/real/test_real_mmp.py
@@ -172,9 +172,8 @@ def de_bdt_2017_votes():
     return wahlkreis_votes, party_votes
 
 
-def test_de_bdt_2017(de_bdt_2017_votes):
-    # https://www.bundeswahlleiter.de/dam/jcr/3f3d42ab-faef-4553-bdf8-ac089b7de86a/btw17_heft3.pdf
-    wahlkreis_votes, party_votes = de_bdt_2017_votes
+def get_de_bdt_evaluator():
+    sainte_lague = votelib.evaluate.proportional.HighestAverages('sainte_lague')
     land_inhab = {
         'Schleswig-Holstein': 2673803,
         'Hamburg': 1525090,
@@ -193,7 +192,6 @@ def test_de_bdt_2017(de_bdt_2017_votes):
         'Sachsen-Anhalt': 2145671,
         'Thüringen': 2077901,
     }
-    sainte_lague = votelib.evaluate.proportional.HighestAverages('sainte_lague')
     land_seats = sainte_lague.evaluate(land_inhab, 598)
     land_wk_eval = votelib.evaluate.core.ByConstituency(
         votelib.evaluate.core.PostConverted(
@@ -221,7 +219,7 @@ def test_de_bdt_2017(de_bdt_2017_votes):
         ]),
         sainte_lague
     )
-    total_eval = votelib.evaluate.FixedSeatCount(
+    return votelib.evaluate.FixedSeatCount(
         votelib.evaluate.core.MultistageDistributor([
             land_wk_eval,
             votelib.evaluate.core.PreConverted(
@@ -240,6 +238,12 @@ def test_de_bdt_2017(de_bdt_2017_votes):
         ], depth=2),
         598
     )
+    
+
+def test_de_bdt_2017(de_bdt_2017_votes):
+    # https://www.bundeswahlleiter.de/dam/jcr/3f3d42ab-faef-4553-bdf8-ac089b7de86a/btw17_heft3.pdf
+    wahlkreis_votes, party_votes = de_bdt_2017_votes
+    total_eval = get_de_bdt_evaluator()
     land_result = total_eval.evaluate([wahlkreis_votes, party_votes])
     bund_result = votelib.convert.MergedDistributions().convert(land_result)
     assert bund_result == {
@@ -249,3 +253,11 @@ def test_de_bdt_2017(de_bdt_2017_votes):
     assert land_result['Mecklenburg-Vorpommern'] == {
         'CDU': 6, 'SPD': 2, 'AfD': 3, 'FDP': 1, 'DIE LINKE': 3, 'GRÜNE': 1
     }
+
+
+def get_evaluators():
+    return [
+        get_de_bdt_evaluator(),
+        NZ_ELECTORATE_EVAL,
+        NZ_PARTYLIST_EVAL,
+    ]

--- a/tests/test_persist.py
+++ b/tests/test_persist.py
@@ -3,34 +3,67 @@ import sys
 import os
 import json
 import decimal
+import importlib
 
 import pytest
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import votelib
 import votelib.convert
+import votelib.evaluate
+import votelib.evaluate.auxiliary
 import votelib.evaluate.condorcet
 import votelib.evaluate.core
 import votelib.evaluate.proportional
 import votelib.evaluate.sequential
 import votelib.evaluate.threshold
 
+sys.path.append(os.path.join(os.path.dirname(__file__)))
+import test_score
 
-@pytest.mark.parametrize('evaluator', list(votelib.evaluate.condorcet.EVALUATORS.values()) + [
-    votelib.evaluate.core.PreConverted(
-        votelib.convert.ScoreToRankedVotes(),
-        votelib.evaluate.sequential.TransferableVoteSelector(quota_function='droop'),
-    ),
-    votelib.evaluate.core.PostConverted(
-        votelib.evaluate.sequential.PreferenceAddition(),
-        votelib.convert.SelectionToDistribution()
-    ),
+sys.path.append(os.path.join(os.path.dirname(__file__), 'real'))
+import test_real_listbased
+import test_real_mmp
+import test_real_proportional
+
+
+CONDORCET_EVALUATORS = list(votelib.evaluate.condorcet.EVALUATORS.values())
+SIMPLE_EVALUATORS = [
     votelib.evaluate.core.Conditioned(
         votelib.evaluate.threshold.RelativeThreshold(decimal.Decimal('.05')),
         votelib.evaluate.proportional.PureProportionality(),
     ),
-    # TODO add vote checkers and evaluators from the "real" tests folder
-])
+    votelib.evaluate.Plurality(),
+]
+RANKED_EVALUATORS = [
+    votelib.evaluate.core.PostConverted(
+        votelib.evaluate.sequential.PreferenceAddition(),
+        votelib.convert.SelectionToDistribution()
+    ),
+]
+SCORE_EVALUATORS = [
+    votelib.evaluate.core.PreConverted(
+        votelib.convert.ScoreToRankedVotes(),
+        votelib.evaluate.sequential.TransferableVoteSelector(
+            quota_function='droop',
+            retainer=votelib.evaluate.core.TieBreaking(
+                votelib.evaluate.Plurality(),
+                votelib.evaluate.auxiliary.InputOrderSelector(),
+            )
+        ),
+    ),
+] + list(test_score.EVALS.values())
+
+
+@pytest.mark.parametrize('evaluator',
+    SIMPLE_EVALUATORS
+    + RANKED_EVALUATORS
+    + SCORE_EVALUATORS
+    + CONDORCET_EVALUATORS
+    + test_real_listbased.get_evaluators()
+    + test_real_mmp.get_evaluators()
+    + test_real_proportional.get_evaluators()
+)
 def test_roundtrip(evaluator):
     dict_form = votelib.persist.to_dict(evaluator)
     serial = json.dumps(dict_form)
@@ -39,3 +72,15 @@ def test_roundtrip(evaluator):
     roundtrip = json.dumps(roundtrip_dict_form)
     assert dict_form == roundtrip_dict_form
     assert serial == roundtrip
+
+
+def test_score_equal():
+    for ev in SCORE_EVALUATORS:
+        roundtripped = votelib.persist.from_dict(
+            json.loads(json.dumps(votelib.persist.to_dict(ev)))
+        )
+        print(ev, roundtripped)
+        print(ev.to_dict())
+        print(roundtripped.to_dict())
+        for votes_name, votes in test_score.VOTES.items():
+            assert ev.evaluate(votes, 1) == roundtripped.evaluate(votes, 1)

--- a/tests/test_persist.py
+++ b/tests/test_persist.py
@@ -1,0 +1,41 @@
+
+import sys
+import os
+import json
+import decimal
+
+import pytest
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+import votelib
+import votelib.convert
+import votelib.evaluate.condorcet
+import votelib.evaluate.core
+import votelib.evaluate.proportional
+import votelib.evaluate.sequential
+import votelib.evaluate.threshold
+
+
+@pytest.mark.parametrize('evaluator', list(votelib.evaluate.condorcet.EVALUATORS.values()) + [
+    votelib.evaluate.core.PreConverted(
+        votelib.convert.ScoreToRankedVotes(),
+        votelib.evaluate.sequential.TransferableVoteSelector(quota_function='droop'),
+    ),
+    votelib.evaluate.core.PostConverted(
+        votelib.evaluate.sequential.PreferenceAddition(),
+        votelib.convert.SelectionToDistribution()
+    ),
+    votelib.evaluate.core.Conditioned(
+        votelib.evaluate.threshold.RelativeThreshold(decimal.Decimal('.05')),
+        votelib.evaluate.proportional.PureProportionality(),
+    ),
+    # TODO add vote checkers and evaluators from the "real" tests folder
+])
+def test_roundtrip(evaluator):
+    dict_form = votelib.persist.to_dict(evaluator)
+    serial = json.dumps(dict_form)
+    print(serial)
+    roundtrip_dict_form = votelib.persist.from_dict(json.loads(serial)).to_dict()
+    roundtrip = json.dumps(roundtrip_dict_form)
+    assert dict_form == roundtrip_dict_form
+    assert serial == roundtrip

--- a/votelib/__init__.py
+++ b/votelib/__init__.py
@@ -23,10 +23,10 @@ wrap it into a formalized and named election system.
 '''
 
 from . import evaluate
-from .util import from_dict, default_serialization    # noqa: F401
+from .persist import simple_serialization    # noqa: F401
 
 
-@default_serialization
+@simple_serialization
 class VotingSystem:
     '''A named voting system. Wraps an election evaluator.
 

--- a/votelib/__init__.py
+++ b/votelib/__init__.py
@@ -23,8 +23,10 @@ wrap it into a formalized and named election system.
 '''
 
 from . import evaluate
+from .util import from_dict, default_serialization
 
 
+@default_serialization
 class VotingSystem:
     '''A named voting system. Wraps an election evaluator.
 

--- a/votelib/__init__.py
+++ b/votelib/__init__.py
@@ -23,7 +23,7 @@ wrap it into a formalized and named election system.
 '''
 
 from . import evaluate
-from .util import from_dict, default_serialization
+from .util import from_dict, default_serialization    # noqa: F401
 
 
 @default_serialization

--- a/votelib/candidate.py
+++ b/votelib/candidate.py
@@ -182,7 +182,7 @@ class Coalition(ElectionParty):
 
     def __init__(self,
                  parties: List[PoliticalParty],
-                 name: str = None,
+                 name: Optional[str] = None,
                  number: Optional[int] = None,
                  affiliations: Optional[List[PoliticalParty]] = None,
                  lead: Optional[Person] = None,

--- a/votelib/candidate.py
+++ b/votelib/candidate.py
@@ -26,6 +26,8 @@ import abc
 import collections
 from typing import Any, List, Optional, Union
 
+from .persist import simple_serialization
+
 
 class CandidateError(Exception):
     '''A candidate is invalid in the given context.
@@ -93,6 +95,7 @@ class IndividualElectionOption(Candidate):
     '''
 
 
+@simple_serialization
 class Person(IndividualElectionOption):
     '''A physical person standing for the election.
 
@@ -115,6 +118,7 @@ class Person(IndividualElectionOption):
         self.number = number
         self.membership = membership
         self.candidacy_for = candidacy_for
+        self.properties = properties
 
     def __repr__(self) -> str:
         return (
@@ -134,6 +138,7 @@ class ElectionParty(Candidate):
     '''
 
 
+@simple_serialization
 class PoliticalParty(ElectionParty):
     '''A political party or movement that is eligible to stand in elections.
 
@@ -157,6 +162,7 @@ class PoliticalParty(ElectionParty):
         self.number = number
         self.affiliations = affiliations
         self.lead = lead
+        self.properties = properties
 
     def __repr__(self) -> str:
         return (
@@ -166,6 +172,7 @@ class PoliticalParty(ElectionParty):
         )
 
 
+@simple_serialization
 class Coalition(ElectionParty):
     '''A coalition of two or more election-eligible parties.
 
@@ -212,6 +219,7 @@ class Coalition(ElectionParty):
         )
 
 
+@simple_serialization
 class IndividualToPartyMapper:
     '''Define mapping from individuals to parties.
 
@@ -282,6 +290,7 @@ class IndividualToPartyMapper:
             return party
 
 
+@simple_serialization
 class BlankVoteOption(ElectionParty, IndividualElectionOption):
     '''A base class for blank (non-partisan) vote choices.
 
@@ -356,6 +365,7 @@ class Nominator(metaclass=abc.ABCMeta):
 
 
 # Nominators (checkers)
+@simple_serialization
 class BasicNominator(Nominator):
     '''Validate that the election candidates are valid objects.
 
@@ -380,6 +390,7 @@ class BasicNominator(Nominator):
             raise CandidateError('blank vote')
 
 
+@simple_serialization
 class PersonNominator(Nominator):
     '''Validate that election candidates are physical persons and not parties.
 
@@ -400,7 +411,6 @@ class PersonNominator(Nominator):
         :param candidate: Candidate to be checked.
         :raises CandidateError: If a candidate is invalid.
         '''
-        print(candidate, isinstance(candidate, IndividualElectionOption))
         if not isinstance(candidate, IndividualElectionOption):
             raise CandidateError(candidate, IndividualElectionOption)
         if isinstance(candidate, BlankVoteOption):
@@ -412,6 +422,7 @@ class PersonNominator(Nominator):
             )
 
 
+@simple_serialization
 class PartyNominator(Nominator):
     '''Check that election candidates are electoral parties, not persons.
 

--- a/votelib/candidate.py
+++ b/votelib/candidate.py
@@ -377,7 +377,7 @@ class BasicNominator(Nominator):
         if not isinstance(candidate, Candidate):
             raise CandidateError(f'invalid candidate {candidate}')
         if not self.allow_blank and isinstance(candidate, BlankVoteOption):
-            raise CandidateError(f'blank vote')
+            raise CandidateError('blank vote')
 
 
 class PersonNominator(Nominator):

--- a/votelib/component/rankscore.py
+++ b/votelib/component/rankscore.py
@@ -10,6 +10,8 @@ from fractions import Fraction
 from typing import List, Any
 from numbers import Number
 
+from ..persist import simple_serialization
+
 
 def select_padded(sequence: List[Any], n: int, pad_with: Any = 0) -> List[Any]:
     '''Select n leading elements from sequence, padding with pad_with.
@@ -38,6 +40,7 @@ class RankScorer(metaclass=abc.ABCMeta):
         raise NotImplementedError
 
 
+@simple_serialization
 class Borda(RankScorer):
     '''Borda rank scorer, corresponding to the original Borda count variant.
 
@@ -100,6 +103,7 @@ class Borda(RankScorer):
             )
 
 
+@simple_serialization
 class Dowdall(RankScorer):
     '''Dowdall (Nauru) rank scorer.
 
@@ -119,6 +123,7 @@ class Dowdall(RankScorer):
         return [Fraction(1, rank + 1) for rank in range(n_ranked)]
 
 
+@simple_serialization
 class Geometric(RankScorer):
     '''A geometric progression rank scorer.
 
@@ -144,6 +149,7 @@ class Geometric(RankScorer):
         return [Fraction(1, self.base ** rank) for rank in range(n_ranked)]
 
 
+@simple_serialization
 class ModifiedBorda(RankScorer):
     '''Modified Borda count rank scorer.
 
@@ -164,6 +170,7 @@ class ModifiedBorda(RankScorer):
         return [n_ranked - rank for rank in range(n_ranked)]
 
 
+@simple_serialization
 class FixedTop(RankScorer):
     '''A rank scorer with fixed score for the top rank.
 
@@ -187,6 +194,7 @@ class FixedTop(RankScorer):
         return [max(self.top - rank, 0) for rank in range(n_ranked)]
 
 
+@simple_serialization
 class SequenceBased(RankScorer):
     '''A rank scorer with a predetermined sequence of scores.
 

--- a/votelib/component/transfer.py
+++ b/votelib/component/transfer.py
@@ -24,6 +24,7 @@ from numbers import Number
 from ..candidate import Candidate
 from ..vote import RankedVoteType
 from ..evaluate.proportional import LargestRemainder
+from ..persist import simple_serialization
 
 
 def ranked_next(vote: RankedVoteType,
@@ -188,7 +189,26 @@ class SimpleVoteTransferer(VoteTransferer):
             (to_remove if cand in may_remove else to_retain).append(cand)
         return to_retain, to_remove
 
+    def _subtract(self,
+                  cand_alloc: Dict[RankedVoteType, Number],
+                  quota: int,
+                  ) -> None:
+        # Remove a total of *quota* votes from values of *cand_alloc*.
+        # Hare STV does this randomly, Gregory STV uses exact proportional
+        # fractions.
+        raise NotImplementedError
 
+    def _distribute_equal_ranking(self,
+                                  targets: FrozenSet[Candidate],
+                                  n_votes: int,
+                                  ) -> Dict[Candidate, int]:
+        # Distribute a total of *n_votes* among candidates in *targets*.
+        # Hare STV does this randomly, Gregory STV uses exact proportional
+        # fractions.
+        raise NotImplementedError
+
+
+@simple_serialization
 class Hare(SimpleVoteTransferer):
     '''Hare (random ballot selection) vote transferer.
 
@@ -244,6 +264,7 @@ class Hare(SimpleVoteTransferer):
         return result
 
 
+@simple_serialization
 class Gregory(SimpleVoteTransferer):
     '''Gregory (fractional) vote transferer.
 

--- a/votelib/convert.py
+++ b/votelib/convert.py
@@ -21,6 +21,7 @@ from .candidate import \
     Candidate, Constituency, IndividualElectionOption, ElectionParty
 from .vote import RankedVoteType, ScoreVoteType
 from .component import rankscore
+from .persist import simple_serialization
 
 
 def _subtract_lowest(scores: Dict[Any, int],
@@ -43,6 +44,7 @@ class Converter:
 
 
 # Aggregators from more complicated votes to simple magnitudes
+@simple_serialization
 class ApprovalToSimpleVotes:
     '''Aggregate approval votes to simple votes.
 
@@ -75,6 +77,7 @@ class ApprovalToSimpleVotes:
         return dict(agg_votes)
 
 
+@simple_serialization
 class ScoreToSimpleVotes:
     '''Aggregate scores (cardinal votes) to simple votes.
 
@@ -244,6 +247,7 @@ class ScoreToSimpleVotes:
         return scores
 
 
+@simple_serialization
 class RankedToPositionalVotes:
     '''Aggregate ranked votes to simple votes.
 
@@ -292,6 +296,7 @@ class RankedToPositionalVotes:
         return util.descending_dict(agg_votes)
 
 
+@simple_serialization
 class RankedToCondorcetVotes:
     '''Aggregate ranked votes to counts of pairwise wins.
 
@@ -339,6 +344,7 @@ class RankedToCondorcetVotes:
         return dict(counts)
 
 
+@simple_serialization
 class ScoreToRankedVotes:
     '''Convert score votes to ranked votes.
 
@@ -393,6 +399,7 @@ class ScoreToRankedVotes:
 
 
 # Inverters
+@simple_serialization
 class InvertedSimpleVotes:
     '''Vote inverter to represent negative simple votes.
 
@@ -406,6 +413,7 @@ class InvertedSimpleVotes:
 
 
 # Individual/party converters
+@simple_serialization
 class IndividualToPartyVotes:
     '''Aggregate votes for individual candidates to votes for their parties.
 
@@ -434,6 +442,7 @@ class IndividualToPartyVotes:
         return dict(aggregated)
 
 
+@simple_serialization
 class IndividualToPartyResult:
     '''Aggregate individual elected candidates to results for their parties.
 
@@ -465,6 +474,7 @@ class IndividualToPartyResult:
         return dict(aggregated)
 
 
+@simple_serialization
 class GroupVotesByParty:
     '''Group individual simple votes to a dict nested by their parties.
 
@@ -496,6 +506,7 @@ class GroupVotesByParty:
         return aggregated
 
 
+@simple_serialization
 class SelectionToDistribution:
     '''Adapt selection results to distribution (seat count) format.
 
@@ -514,6 +525,7 @@ class SelectionToDistribution:
         return {cand: self.amount for cand in elected}
 
 
+@simple_serialization
 class MergedSelections:
     '''Compile candidates elected in constituencies to a single result list.
 
@@ -552,6 +564,7 @@ class MergedSelections:
         return ranks
 
 
+@simple_serialization
 class MergedDistributions:
     '''Merge many distribution election results into one.
 
@@ -582,6 +595,7 @@ class MergedDistributions:
 
 
 # Constituency-defined vote aggregators by party or district
+@simple_serialization
 class VoteTotals:
     '''Count total votes/results for each candidate in all constituencies.
 
@@ -602,6 +616,7 @@ class VoteTotals:
         return all_districts
 
 
+@simple_serialization
 class ConstituencyTotals:
     '''Count total votes (or results) for all candidates in each constituency.
 
@@ -622,6 +637,7 @@ class ConstituencyTotals:
         }
 
 
+@simple_serialization
 class PartyTotals:
     '''Count total votes for parties from grouped votes for its candidates.
 
@@ -645,13 +661,14 @@ class PartyTotals:
         }
 
 
+@simple_serialization
 class ByConstituency:
     '''Perform conversion for each constituency votes/results separately.
 
     :param converter: A converter to wrap. Will be called to convert votes (or
         results) for each constituency separately.
     '''
-    def __init__(self, converter):
+    def __init__(self, converter: Converter):
         self.converter = converter
 
     def convert(self,
@@ -669,6 +686,7 @@ class ByConstituency:
         }
 
 
+@simple_serialization
 class InvalidVoteEliminator:
     '''Only allow through votes that are declared valid by a given validator.
 
@@ -700,6 +718,7 @@ class InvalidVoteEliminator:
         return votes
 
 
+@simple_serialization
 class RoundedVotes:
     '''Round vote counts to the given number of decimal digits.
 
@@ -755,6 +774,7 @@ class RoundedVotes:
         }
 
 
+@simple_serialization
 class SubsettedVotes:
     '''Subset the votes to only concern a subset of candidates.
 

--- a/votelib/evaluate/approval.py
+++ b/votelib/evaluate/approval.py
@@ -13,9 +13,11 @@ from fractions import Fraction
 from typing import List, FrozenSet, Dict
 
 from ..candidate import Candidate
+from ..persist import simple_serialization
 from . import core
 
 
+@simple_serialization
 class ProportionalApproval:
     '''Proportional Approval Voting (PAV) evaluator. [#wpav]_
 
@@ -112,6 +114,7 @@ class ProportionalApproval:
         )
 
 
+@simple_serialization
 class SequentialProportionalApproval:
     '''Sequential Proportional Approval Voting (SPAV) evaluator. [#wspav]_
 

--- a/votelib/evaluate/auxiliary.py
+++ b/votelib/evaluate/auxiliary.py
@@ -13,6 +13,7 @@ from typing import Any, List, Dict, Optional
 from numbers import Number
 
 from ..candidate import Candidate
+from ..persist import simple_serialization
 from .. import util
 
 
@@ -30,6 +31,7 @@ class SpoiledBallotRemover:
 """
 
 
+@simple_serialization
 class RandomUnrankedBallotSelector:
     '''Select candidates by drawing random simple ballots from the tally.
 
@@ -57,6 +59,7 @@ class RandomUnrankedBallotSelector:
         return util.select_n_random(votes, n_seats)
 
 
+@simple_serialization
 class Sortitor:
     '''Perform sortition (random sampling) among the candidates.
 
@@ -87,6 +90,7 @@ class Sortitor:
         }, n_seats)
 
 
+@simple_serialization
 class InputOrderSelector:
     '''Select first N candidates as they appear in the vote counts.
 

--- a/votelib/evaluate/cardinal.py
+++ b/votelib/evaluate/cardinal.py
@@ -48,10 +48,10 @@ class ScoreVoting:
         )
 
     def to_dict(self) -> Dict[str, Any]:
-        return dict(
-            {'class': persist.scoped_class_name(self)},
-            **self._agg.to_dict()
-        )
+        return {
+            **self._agg.to_dict(),
+            'class': persist.scoped_class_name(self)
+        }
 
     def evaluate(self,
                  votes: Dict[ScoreVoteType, int],
@@ -116,13 +116,18 @@ class MajorityJudgment:
             truncation=truncation,
             bottom_value=bottom_value,
         )
+        self.tie_breaking = tie_breaking
         self.tie_breaker = getattr(self, '_tiebreak_' + tie_breaking)
 
     def to_dict(self) -> Dict[str, Any]:
-        return dict(
-            {'class': persist.scoped_class_name(self)},
-            **self._agg.to_dict()
-        )
+        out = {
+            'class': persist.scoped_class_name(self),
+            'tie_breaking': self.tie_breaking,
+        }
+        for key, val in self._agg.to_dict().items():
+            if key not in ('function', 'class'):
+                out[key] = val
+        return out
 
     def evaluate(self,
                  votes: Dict[Candidate, Dict[Number, int]],
@@ -309,8 +314,8 @@ class STAR:
             'runoff_added_fraction': self.runoff_added_fraction,
             'runoff_evaluator': self.runoff_evaluator.to_dict(),
         }
-        for key, val in self._agg.to_dict():
-            if key != 'function':
+        for key, val in self._agg.to_dict().items():
+            if key not in ('function', 'class'):
                 out[key] = val
         return out
 

--- a/votelib/evaluate/core.py
+++ b/votelib/evaluate/core.py
@@ -903,8 +903,9 @@ class ByParty:
         results = collections.defaultdict(dict)
         for party, n_party_seats in overall_result.items():
             party_votes = {
-                constituency: sum(subset_conv.convert(cvotes, [party]).values())
-                for constituency, cvotes in votes.items()
+                constituency: sum(
+                    subset_conv.convert(cvotes, [party]).values()
+                ) for constituency, cvotes in votes.items()
             }
             if accepts_prev_gains(allocator):
                 party_prev_gains = {

--- a/votelib/evaluate/openlist.py
+++ b/votelib/evaluate/openlist.py
@@ -78,6 +78,7 @@ class ThresholdOpenList:
                  list_precedence: bool = False,
                  ):
         self.jump_fraction = jump_fraction
+        self.quota_fraction = quota_fraction
         if quota_function is not None and quota_fraction != 1:
             wrapped = quota.construct(quota_function)
 

--- a/votelib/evaluate/openlist.py
+++ b/votelib/evaluate/openlist.py
@@ -29,8 +29,10 @@ from . import core
 from .. import util
 from ..candidate import Candidate
 from ..component import quota
+from ..persist import simple_serialization
 
 
+@simple_serialization
 class ThresholdOpenList:
     '''A threshold-based open list evaluator.
 
@@ -138,6 +140,7 @@ class ThresholdOpenList:
                 return elected
 
 
+@simple_serialization
 class ListOrderTieBreaker:
     '''A wrapper for any selector for open-list candidate selection.
 

--- a/votelib/evaluate/proportional.py
+++ b/votelib/evaluate/proportional.py
@@ -16,12 +16,14 @@ from numbers import Number
 from .. import util
 from ..candidate import Candidate
 from ..component import quota, divisor
+from ..persist import simple_serialization
 from . import core
 
 
 INF = float('inf')
 
 
+@simple_serialization
 class PureProportionality:
     '''Distribute seats among candidates strictly proportionally (no rounding).
 
@@ -80,6 +82,7 @@ class PureProportionality:
         }
 
 
+@simple_serialization
 class QuotaDistributor:
     '''Distribute seats proportionally, according to multiples of quota filled.
 
@@ -153,6 +156,7 @@ class QuotaDistributor:
         return selected
 
 
+@simple_serialization
 class LargestRemainder:
     '''Distribute seats proportionally, rounding by largest remainder.
 
@@ -216,6 +220,7 @@ class LargestRemainder:
         return quota_elected
 
 
+@simple_serialization
 class HighestAverages:
     '''Distribute seats proportionally by ordering divided vote counts.
 

--- a/votelib/evaluate/sequential.py
+++ b/votelib/evaluate/sequential.py
@@ -14,10 +14,12 @@ from numbers import Number
 from ..candidate import Candidate
 from ..vote import RankedVoteType
 from ..component import transfer, quota
+from ..persist import simple_serialization
 from . import core
 from .. import util
 
 
+@simple_serialization
 class TransferableVoteSelector:
     '''Select candidates by eliminating and transfering votes among them.
 
@@ -263,6 +265,7 @@ class TransferableVoteSelector:
 
 
 # Gradual preference addition
+@simple_serialization
 class PreferenceAddition:
     '''Evaluates ranked votes by stepwise addition of lower preferences.
 

--- a/votelib/evaluate/threshold.py
+++ b/votelib/evaluate/threshold.py
@@ -14,8 +14,10 @@ from . import core
 from .. import util
 from ..candidate import Candidate, ElectionParty
 from ..component import quota
+from ..persist import simple_serialization
 
 
+@simple_serialization
 class QuotaSelector:
     '''Quota threshold (plurality) selector.
 
@@ -75,6 +77,7 @@ class QuotaSelector:
         return elected
 
 
+@simple_serialization
 class AbsoluteThreshold:
     '''Absolute threshold seatless selector.
 
@@ -109,6 +112,7 @@ class AbsoluteThreshold:
         ]
 
 
+@simple_serialization
 class RelativeThreshold:
     '''Relative threshold seatless selector.
 
@@ -147,6 +151,7 @@ class RelativeThreshold:
         ]
 
 
+@simple_serialization
 class CoalitionMemberBracketer:
     '''Dispatch to different seatless selectors for coalitions.
 
@@ -196,6 +201,7 @@ class CoalitionMemberBracketer:
         ]
 
 
+@simple_serialization
 class PropertyBracketer:
     '''Dispatch to different seatless selectors for some types of parties.
 
@@ -249,6 +255,7 @@ class PropertyBracketer:
         return results
 
 
+@simple_serialization
 class AlternativeThresholds:
     '''An OR function for threshold evaluators.
 
@@ -300,6 +307,7 @@ class AlternativeThresholds:
         return list(sorted(all_results, key=mean_rank))
 
 
+@simple_serialization
 class PreviousGainThreshold:
     '''A threshold on gained seats in previous election rounds.
 

--- a/votelib/persist.py
+++ b/votelib/persist.py
@@ -1,0 +1,169 @@
+
+import sys
+import inspect
+import importlib
+from fractions import Fraction
+from decimal import Decimal
+from typing import Any, List, Dict, Callable
+
+
+def simple_serialization(class_: type) -> type:
+    '''A decorator to provide a simple to_dict() serialization method.
+
+    The resulting method will serialize all object attributes corresponding
+    to the class's constructor parameter names. Therefore, this decorator
+    is only useful when the class stores all its original parameters
+    unchanged (or in any other form acceptable to its constructor).
+    '''
+    if hasattr(class_, 'serialize_params'):
+        param_names = class_.serialize_params
+    else:
+        param_names = list(inspect.signature(class_.__init__).parameters.keys())
+        if 'self' in param_names:
+            param_names.remove('self')
+        if param_names == ['args', 'kwargs'] and class_.__init__ == object.__init__:
+            param_names = []
+
+    def to_dict(self) -> Dict[str, Any]:
+        out_dict = {'class': scoped_class_name(self)}
+        for attr in param_names:
+            out_dict[attr] = serialize_value(getattr(self, attr))
+        return out_dict
+
+    class_.to_dict = to_dict
+    return class_
+
+
+def serialize_value(value: Any) -> Any:
+    if hasattr(value, 'to_dict'):
+        return value.to_dict()
+    elif isinstance(value, tuple(ATOMIC_TYPES)):
+        return value
+    elif type(value) in CONVERTIBLE_TYPES:
+        return CONVERTIBLE_TYPES[type(value)](value)
+    elif hasattr(value, '__iter__'):
+        if hasattr(value, 'items') and hasattr(value, 'keys'):
+            if all(isinstance(key, str) in value.keys()):
+                return {key: serialize_value(val) for key, val in value.items()}
+            else:
+                raise NotImplementedError('serializing a dictionary with nonstring keys')
+        else:
+            return [serialize_value(val) for val in value]
+    elif hasattr(value, '__call__'):
+        return {'callable': '.'.join((value.__module__, value.__name__))}
+    else:
+        raise ValueError(f'cannot serialize {value!r} to dict format')
+
+
+def deserialize_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        if 'type' in value and is_scoped_identifier(value['type']):
+            return deserialize_typed(value)
+        elif 'class' in value and is_scoped_identifier(value['class']):
+            return deserialize_class(value)
+        elif 'callable' in value and is_scoped_identifier(value['callable']):
+            return get_object(value['callable'])
+        else:
+            return {key: deserialize_value(val) for key, val in value.items()}
+    elif isinstance(value, tuple(ATOMIC_TYPES)):
+        return value
+    elif isinstance(value, list):
+        return [deserialize_value(val) for val in value]
+    else:
+        raise ValueError(f'cannot deserialize {value!r}, type unknown')
+
+
+def deserialize_typed(typedef: Dict[str, Any]) -> Any:
+    typeobj = get_object(typedef['type'])
+    if 'value' in typedef:
+        return typeobj(typedef['value'])
+    elif 'arguments' in typedef:
+        return typeobj(*typedef['arguments'])
+    elif 'parameters' in typedef:
+        return typeobj(**typedef['parameters'])
+    else:
+        raise ValueError(f'invalid typed value contents: {typedef!r}')
+
+
+def deserialize_class(clsdef: Dict[str, Any]) -> Any:
+    cls = get_object(clsdef['class'])
+    params = clsdef.copy()
+    del params['class']
+    if hasattr(cls, 'from_dict'):
+        return cls.from_dict(params)
+    else:
+        for key, inner_val in params.items():
+            params[key] = deserialize_value(inner_val)
+        return cls(**params)
+
+
+def get_object(identifier: str) -> Any:
+    if '.' not in identifier:
+        return globals()[identifier]
+    else:
+        module, name = identifier.rsplit('.', 1)
+        if module not in sys.modules:
+            importlib.import_module(module)
+        return getattr(sys.modules[module], name)
+
+
+def from_dict(value: Dict[str, Any]) -> Any:
+    if not isinstance(value, dict):
+        raise ValueError('invalid votelib object def: dict expected,'
+                         f'got {value!r}')
+    elif 'class' not in value:
+        raise ValueError('invalid votelib object def: must have a class key')
+    elif not is_scoped_identifier(value['class']):
+        inval_cls = value['class']
+        raise ValueError(f"invalid votelib class def: {inval_cls}")
+    else:
+        return deserialize_value(value)
+
+
+def to_dict(obj: Any) -> Dict[str, Any]:
+    return serialize_value(obj)
+
+
+def is_scoped_identifier(value: Any):
+    return (
+        isinstance(value, str)
+        and not value.startswith('.')
+        and all(chunk.isidentifier() for chunk in value.split('.'))
+    )
+
+
+def scoped_class_name(value: Any):
+    cls = value.__class__
+    return '.'.join((cls.__module__, cls.__name__))
+
+
+def fraction_to_json(f: Fraction) -> Dict[str, Any]:
+    return {'type': 'Fraction', 'arguments': f.as_integer_ratio()}
+
+
+def decimal_to_json(d: Decimal) -> Dict[str, Any]:
+    return {'type': 'Decimal', 'value': str(d)}
+
+
+def sequence_to_json_factory(typeobj):
+    typename = typeobj.__name__
+
+    def sequence_to_json(seq) -> Dict[str, Any]:
+        return {'type': typename, 'value': [serialize_value(v) for v in seq]}
+
+    return sequence_to_json
+
+
+ATOMIC_TYPES: List[type] = [
+    str, int, float, bool, type(None),
+]
+
+CONVERTIBLE_TYPES: Dict[type, Callable] = {
+    Fraction: fraction_to_json,
+    Decimal: decimal_to_json,
+}
+
+SEQUENCE_TYPES: List[type] = [frozenset, tuple]
+
+for seqtype in SEQUENCE_TYPES:
+    CONVERTIBLE_TYPES[seqtype] = sequence_to_json_factory(seqtype)

--- a/votelib/util.py
+++ b/votelib/util.py
@@ -3,17 +3,13 @@
 There should normally be no need to use these functions directly.
 '''
 
-import sys
 import operator
 import itertools
 import collections
 import bisect
 import random
-import inspect
-import importlib
 from fractions import Fraction
-from decimal import Decimal
-from typing import Any, List, Tuple, Dict, FrozenSet, Union, Callable
+from typing import Any, List, Tuple, Dict, FrozenSet, Union
 from numbers import Number
 
 from .vote import RankedVoteType
@@ -126,128 +122,3 @@ def exact_mean(values: List[Union[int, Fraction]]) -> Fraction:
 EXACT_AGGREGATORS = {
     'mean': exact_mean,
 }
-
-
-def default_serialization(class_):
-    '''A class decorator to provide a to_dict() serialization method.'''
-    param_names = inspect.signature(class_.__init__).parameters.keys()
-
-    def to_dict(self) -> Dict[str, Any]:
-        out_dict = {'class': self.__class__.__name__}
-        for attr in param_names:
-            out_dict[attr] = serialize_value(getattr(self, attr))
-        return out_dict
-
-    class_.to_dict = to_dict
-    return class_
-
-
-def serialize_value(value: Any) -> Any:
-    if hasattr(value, 'to_dict'):
-        return value.to_dict()
-    elif isinstance(value, ATOMIC_TYPES):
-        return value
-    elif type(value) in CONVERTIBLE_TYPES:
-        return CONVERTIBLE_TYPES[type(value)](value)
-    elif hasattr(value, '__iter__'):
-        if hasattr(value, 'items'):
-            return {key: serialize_value(val) for key, val in value.items()}
-        else:
-            return [serialize_value(val) for val in value]
-    elif hasattr(value, '__call__'):
-        return {'callable': '.'.join((value.__module__, value.__name__))}
-    else:
-        raise ValueError(f'cannot serialize {value!r} to dict format')
-
-
-def deserialize_value(value: Any) -> Any:
-    if isinstance(value, dict):
-        if 'type' in value and is_scoped_identifier(value['type']):
-            typeobj = get_object(value['type'])
-            if 'value' in value:
-                return typeobj(value['value'])
-            elif 'arguments' in value:
-                return typeobj(*value['arguments'])
-            elif 'parameters' in value:
-                return typeobj(**value['parameters'])
-            else:
-                raise ValueError(f'invalid dict contents: {value!r}')
-        elif 'class' in value and is_scoped_identifier(value['class']):
-            cls = get_object(value['class'])
-            return cls(**{
-                key: deserialize_value(inner_val)
-                for key, inner_val in value.items() if key != 'class'
-            })
-        elif 'callable' in value and is_scoped_identifier(value['callable']):
-            return get_object(value['callable'])
-        else:
-            return {key: deserialize_value(val) for key, val in value.items()}
-    elif isinstance(value, ATOMIC_TYPES):
-        return value
-    elif isinstance(value, list):
-        return [deserialize_value(val) for val in value]
-    else:
-        raise ValueError(f'cannot deserialize {value!r}, type unknown')
-
-
-def get_object(identifier: str) -> Any:
-    if '.' not in str:
-        return eval(identifier)
-    else:
-        module, name = identifier.rsplit('.', 1)
-        if module not in sys.modules:
-            importlib.import_module(module)
-        return getattr(sys.modules[module], name)
-
-
-def from_dict(value: Dict[str, Any]) -> Any:
-    if not isinstance(value, dict):
-        raise ValueError('invalid votelib object def: dict expected,'
-                         f'got {value!r}')
-    elif 'class' not in value:
-        raise ValueError('invalid votelib object def: must have a class key')
-    elif not is_scoped_identifier(value['class']):
-        inval_cls = value['class']
-        raise ValueError(f"invalid votelib class def: {inval_cls}")
-    else:
-        return deserialize_value(value)
-
-
-def is_scoped_identifier(value: Any):
-    return (
-        isinstance(value, str)
-        and not value.startswith('.')
-        and all(chunk.isidentifier() for chunk in value.split('.'))
-    )
-
-
-def fraction_to_json(f: Fraction) -> Dict[str, Any]:
-    return {'type': 'Fraction', 'arguments': f.as_integer_ratio()}
-
-
-def decimal_to_json(d: Decimal) -> Dict[str, Any]:
-    return {'type': 'Decimal', 'value': str(d)}
-
-
-def sequence_to_json_factory(typeobj):
-    typename = typeobj.__name__
-
-    def sequence_to_json(seq) -> Dict[str, Any]:
-        return {'type': typename, 'value': [serialize_value(v) for v in seq]}
-
-    return sequence_to_json
-
-
-ATOMIC_TYPES: List[type] = [
-    str, int, float, bool, None,
-]
-
-CONVERTIBLE_TYPES: Dict[type, Callable] = {
-    Fraction: fraction_to_json,
-    Decimal: decimal_to_json,
-}
-
-SEQUENCE_TYPES: List[type] = [frozenset, tuple]
-
-for seqtype in SEQUENCE_TYPES:
-    CONVERTIBLE_TYPES[seqtype] = sequence_to_json_factory(seqtype)


### PR DESCRIPTION
New `votelib.persist` module for serialization and deserialization of voting system components into JSON-ready dictionaries. The format is probably not stable and could use a proper JSON schema.

Closes #11.